### PR TITLE
fix(app): correct fetch cache behavior and add GEMINI.md

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,37 @@
+# Gemini Project Context
+
+This document provides context for the Gemini AI assistant to effectively assist with development tasks in this project.
+
+## Tech Stack
+
+- **Framework**: Next.js
+- **Language**: TypeScript
+- **UI**: React
+- **Styling**: Panda CSS
+- **Testing**: Vitest, Playwright, Storybook
+- **Linting**: ESLint
+- **Formatting**: Prettier
+- **Content Management**: Velite
+- **Package Manager**: pnpm
+
+## Project Commands
+
+The following commands are available in `package.json`:
+
+- `pnpm dev`: Starts the development server with Turbopack.
+- `pnpm build`: Builds the application for production.
+- `pnpm lint`: Lints the codebase using Next.js's ESLint configuration.
+- `pnpm test`: Runs tests using Vitest.
+- `pnpm format:check`: Checks for formatting errors using Prettier.
+- `pnpm format:write`: Formats the code using Prettier.
+- `pnpm storybook`: Starts the Storybook development server.
+- `pnpm build-storybook`: Builds the Storybook for deployment.
+- `pnpm test-storybook`: Runs tests for the Storybook components.
+
+## Code Style and Conventions
+
+- **Formatting**: This project uses Prettier for code formatting. Run `pnpm format:write` to format the code.
+- **Linting**: This project uses ESLint for code linting. Run `pnpm lint` to check for linting errors.
+- **TypeScript**: The project is written in TypeScript. Please adhere to TypeScript best practices.
+- **Styling**: The project uses Panda CSS for styling.
+- **Content**: Content is managed using Velite.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,8 +4,6 @@ import { ExternalPost } from '@/src/features/Posts/types';
 import RssParser from 'rss-parser';
 import { posts } from '#site/content';
 
-export const dynamic = 'force-dynamic';
-
 export default async function Page() {
   const externalPosts = await getZennPosts();
 
@@ -14,7 +12,6 @@ export default async function Page() {
 
 async function getZennPosts(): Promise<ExternalPost[]> {
   const res = await fetch('https://zenn.dev/makotot/feed', {
-    cache: 'force-cache',
     next: { revalidate: 86400 },
   });
   const text = await res.text();


### PR DESCRIPTION
Corrected the fetch cache behavior in `src/app/page.tsx` by removing `force-dynamic` and relying on `next.revalidate`. This ensures that the Zenn feed is re-fetched at most once every 24 hours, as intended. Additionally, a `GEMINI.md` file has been added to the project root to provide context and guidance for the Gemini AI assistant, including details on the tech stack, project commands, and coding conventions.