### PR TITLE
Set Renovate minimum release age to 48 hours

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
   "labels": ["renovate"],
+  "minimumReleaseAge": "48h",
   "packageRules": [
     {
       "matchUpdateTypes": ["patch", "pin", "minor"],


### PR DESCRIPTION
## Summary
- configure Renovate to wait 48 hours after a release before opening update PRs

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68cfe1592994832da2e5b160ead12087